### PR TITLE
Edit explanatory text of Misty Theme.

### DIFF
--- a/_posts/theme/2019-01-11-Misty.md
+++ b/_posts/theme/2019-01-11-Misty.md
@@ -30,14 +30,14 @@ One more rendering demo of introduction text:
 
 ## Installation
 
-Download [misty-theme.css](https://github.com/etigerstudio/typora-misty-theme/releases/latest) and copy it into the themes folder of Typora. Select 'Misty Theme' form the theme list to apply it. You may restart Typora once to help it discover and load the theme file, if 'Misty Theme' cannot be found in the theme list.
+Download [misty-theme.css](https://github.com/etigerstudio/typora-misty-theme/releases/latest) of your platform and copy it into the themes folder of Typora. Select 'Misty Theme' form the theme list to apply it. You may restart Typora once to help it discover and load the theme file, if 'Misty Theme' cannot be found in the theme list.
 
 For detailed reference, please see [Install Theme](https://theme.typora.io/doc/Install-Theme/)
 
 ## Compatibility
 
-This theme is both test on `macOS 10.13.6` and `Windows 10 version 1703`.
+This theme is both test on `macOS 10.13.6` and `Windows 10 version 1703`. However, it has not been tested on `Linux` thoroughly yet and will be tested in future. 
 
-Font fallback list is tweaked for both English and Chinese, on both macOS and Windows, while font weight set on Windows might be *too light* to affect overall readability. This platform-specific issue will be thoroughly tested and addressed at future versions.
+Font fallback list is tweaked for both English and Chinese, on both macOS and Windows. Font weight values have been slightly adjusted on Windows to match Windows-specific rendering characteristic.
 
 > Brought to you with ❤️ by E-Tiger Studio, 2017-2019.

--- a/_posts/theme/2019-01-11-Misty.md
+++ b/_posts/theme/2019-01-11-Misty.md
@@ -38,6 +38,8 @@ For detailed reference, please see [Install Theme](https://theme.typora.io/doc/I
 
 This theme is both test on `macOS 10.13.6` and `Windows 10 version 1703`. However, it has not been tested on `Linux` thoroughly yet and will be tested in future. 
 
-Font fallback list is tweaked for both English and Chinese, on both macOS and Windows. Font weight values have been slightly adjusted on Windows to match Windows-specific rendering characteristic.
+## GitHub
+
+If you find any problem or if you have any idea on this theme, feel free to open an issue or make a pull request at the [GitHub repo](https://github.com/etigerstudio/typora-misty-theme).
 
 > Brought to you with ❤️ by E-Tiger Studio, 2017-2019.


### PR DESCRIPTION
After porting from macOS to Windows, I edited '2019-01-11-Misty.md' (Misty Theme):
1.Delete unnecessary words about compatibility issue as it has been basically addressed for Windows.
2.Add one sentence stating that support for Linux is in progress.
3.Add a link to the repo of theme so that one who spotted a bug could know to open an issue at GitHub.