### PR TITLE
Fix Ursine preview images

### DIFF
--- a/_posts/theme/2019-03-04-Ursine.md
+++ b/_posts/theme/2019-03-04-Ursine.md
@@ -47,8 +47,7 @@ So if you wanna show appreciation that way, just know that this college boy woul
 
 ## Preview
 
-<details>
-<summary>Ursine Polar</summary>
+### Ursine Polar
 
 ![Polar Preview 1](../../media/theme/ursine/polar-1.png)
 ![Polar Preview 2](../../media/theme/ursine/polar-2.png)
@@ -57,10 +56,7 @@ So if you wanna show appreciation that way, just know that this college boy woul
 ![Polar Unibody Preview](../../media/theme/ursine/polar-unibody.png)
 ![Polar Splashscreen](../../media/theme/ursine/polar-splashscreen.png)
 
-</details>
-
-<details>
-<summary>Ursine Umbra</summary>
+### Ursine Umbra
 
 ![Umbra Preview 1](../../media/theme/ursine/umbra-1.png)
 ![Umbra Preview 2](../../media/theme/ursine/umbra-2.png)
@@ -68,8 +64,6 @@ So if you wanna show appreciation that way, just know that this college boy woul
 ![Umbra Source Code Preview](../../media/theme/ursine/umbra-source.png)
 ![Umbra Unibody Preview](../../media/theme/ursine/umbra-unibody.png)
 ![Umbra Splashscreen](../../media/theme/ursine/umbra-splashscreen.png)
-
-</details>
 
 ## Build
 


### PR DESCRIPTION
I didn't realize when I pushed my update to the Ursine page (#86) that collapsible content doesn't work properly on the site, so all the preview images are just text. I just fixed that up by reverting it back to regular Markdown headers and such