### PR TITLE
Typo preventing Whitelines thumbnail from loading

### DIFF
--- a/_posts/theme/2020-07-01-Whitelines.md
+++ b/_posts/theme/2020-07-01-Whitelines.md
@@ -5,7 +5,7 @@ category: theme
 homepage: https://github.com/typora/typora-theme-gallery
 download: https://github.com/typora/typora-theme-gallery/raw/gh-pages/media/theme/whitelines/whitelines.css
 author: Todd Parsons
-thumbnail: Whitelines.png
+thumbnail: whitelines.png
 typora-root-url: ../../
 typora-copy-images-to: ../../media/theme/whitelines
 


### PR DESCRIPTION
Sorry for the spam! Literally just forgot that the thumbnail filename was in lowercase, so when you look on the theme gallery the image doesn't load.