### PR TITLE
feat: add some styles to inline code for theme-han.

### DIFF
--- a/media/theme/han/han.css
+++ b/media/theme/han/han.css
@@ -285,6 +285,14 @@ pre, code, pre tt {
   font-family: Courier, 'Courier New', monospace;
 }
 
+code {
+  background: rgba(135,131,120,.15);
+  color: #EB5757;
+  border-radius: 4px;
+  font-size: 85%;
+  padding: 0.2em 0.4em;
+}
+
 #write .md-fences {
   border: 1px solid #ddd;
   padding: 1em 0.5em;


### PR DESCRIPTION
I add some styles to inline  code. The styles inspired by Notion.

previous:
![image](https://github.com/typora/theme.typora.io/assets/69381867/e7a9154d-6ca4-4f17-a366-2230761a7c03)
after:
<img width="191" alt="image" src="https://github.com/typora/theme.typora.io/assets/69381867/4d679370-2702-4222-8b44-8ce1b4769176">
